### PR TITLE
memes/okay?: Patch clipping of meme animation.

### DIFF
--- a/userbot/modules/memes.py
+++ b/userbot/modules/memes.py
@@ -224,7 +224,7 @@ async def lol(lel):
     okay = "-_-"
     for _ in range(10):
         okay = okay[:-1] + "_-"
-        await lel.edit(okay)
+        await lel.edit(okay, parse_mode='html')
 
 
 @register(outgoing=True, pattern="^.cp(?: |$)(.*)")


### PR DESCRIPTION
Parse the message as HTML coz 4 underscores make a blank italic character in MD parsing, causing the animation to awkwardly clip.