### PR TITLE
Fix a pair of vulns

### DIFF
--- a/userbot/events.py
+++ b/userbot/events.py
@@ -52,6 +52,10 @@ def register(**args):
 
     def decorator(func):
         async def wrapper(check):
+            if check.edit_date and check.is_channel and not check.is_group:
+                # Messages sent in channels can be edited by other users.
+                # Ignore edits that take place in channels.
+                return
             if group_only and not check.is_group:
                 await check.respond("`Are you sure this is a group?`")
                 return

--- a/userbot/modules/system_stats.py
+++ b/userbot/modules/system_stats.py
@@ -5,7 +5,7 @@
 #
 """ Userbot module for getting information about the server. """
 
-from asyncio import create_subprocess_shell as asyncrunapp
+from asyncio import create_subprocess_exec as asyncrunapp
 from asyncio.subprocess import PIPE as asyncPIPE
 from os import remove
 from platform import python_version, uname
@@ -26,9 +26,8 @@ async def sysdetails(sysd):
     """ For .sysd command, get system info using neofetch. """
     if not sysd.text[0].isalpha() and sysd.text[0] not in ("/", "#", "@", "!"):
         try:
-            neo = "neofetch --stdout"
             fetch = await asyncrunapp(
-                neo,
+                "neofetch", "--stdout",
                 stdout=asyncPIPE,
                 stderr=asyncPIPE,
             )
@@ -48,9 +47,8 @@ async def bot_ver(event):
     if not event.text[0].isalpha() and event.text[0] not in ("/", "#", "@",
                                                              "!"):
         if which("git") is not None:
-            invokever = "git describe --all --long"
             ver = await asyncrunapp(
-                invokever,
+                "git", "describe", "--all", "--long",
                 stdout=asyncPIPE,
                 stderr=asyncPIPE,
             )
@@ -58,9 +56,8 @@ async def bot_ver(event):
             verout = str(stdout.decode().strip()) \
                 + str(stderr.decode().strip())
 
-            invokerev = "git rev-list --all --count"
             rev = await asyncrunapp(
-                invokerev,
+                "git", "rev-list", "--all", "--count",
                 stdout=asyncPIPE,
                 stderr=asyncPIPE,
             )
@@ -87,9 +84,8 @@ async def pipcheck(pip):
         pipmodule = pip.pattern_match.group(1)
         if pipmodule:
             await pip.edit("`Searching . . .`")
-            invokepip = f"pip3 search {pipmodule}"
             pipc = await asyncrunapp(
-                invokepip,
+                "pip3", "search", pipmodule,
                 stdout=asyncPIPE,
                 stderr=asyncPIPE,
             )


### PR DESCRIPTION
Any command can be executed unless it specifies at least one of `group_only` or `disable_edited`. The procedure is to:

1. Persuade victim to join channel
2. Promote victim in channel
3. Persuade victim to send message in channel (this can be done through abuse of the lists feature if the victim has a saved glist)
4. Edit the message sent by victim to `.pip ;<SHELL COMMAND>`, where shell command could be `env` to dump environment variables, it could be a curl command to upload the userbot session file, it could be a command to download and execute a shell script that further exploits the unrestricted execution.